### PR TITLE
Update Vapor to 4.90.0: Fix for URI Parsing Vulnerability

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "67fe736c37b0ad958b9d248f010cff6c1baa5c3a",
-        "version" : "4.89.3"
+        "revision" : "6db3d917b5ce5024a84eb265ef65691383305d70",
+        "version" : "4.90.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.89.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.90.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.1")
     ],


### PR DESCRIPTION
Upgraded vapor-oauth to use Vapor 4.90.0, fixing a critical URI parsing security issue. See GHSA-qvxg-wjxc-r4gg for details.