### PR TITLE
Refactor Scope Handling to String Type in Compliance with OAuth RFC Standards

### DIFF
--- a/Sources/VaporOAuth/DefaultImplementations/EmptyCodeManager.swift
+++ b/Sources/VaporOAuth/DefaultImplementations/EmptyCodeManager.swift
@@ -10,7 +10,7 @@ public struct EmptyCodeManager: CodeManager {
         userID: String,
         clientID: String,
         redirectURI: String,
-        scopes: [String]?,
+        scopes: String?,
         codeChallenge: String?,
         codeChallengeMethod: String?,
         nonce: String?
@@ -24,7 +24,7 @@ public struct EmptyCodeManager: CodeManager {
         return nil
     }
 
-    public func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) async throws -> String {
+    public func generateDeviceCode(userID: String, clientID: String, scopes: String?) async throws -> String {
         return ""
     }
 

--- a/Sources/VaporOAuth/Helper/OAuthHelper+remote.swift
+++ b/Sources/VaporOAuth/Helper/OAuthHelper+remote.swift
@@ -3,15 +3,15 @@ import Vapor
 
 actor RemoteTokenResponseActor {
     var remoteTokenResponse: RemoteTokenResponse?
-
+    
     func setRemoteTokenResponse(_ response: RemoteTokenResponse) {
         self.remoteTokenResponse = response
     }
-
+    
     func hasTokenResponse() async -> Bool {
         return remoteTokenResponse != nil
     }
-
+    
     func getRemoteTokenResponse() async throws -> RemoteTokenResponse {
         guard let response = remoteTokenResponse else {
             throw Abort(.internalServerError)
@@ -43,8 +43,8 @@ extension OAuthHelper {
                 
                 let remoteTokenResponse = try await responseActor.getRemoteTokenResponse()
                 
-                if let requiredScopes = scopes {
-                    guard let tokenScopes = remoteTokenResponse.scopes else {
+                if let requiredScopes = scopes?.components(separatedBy: " ") {
+                    guard let tokenScopes = remoteTokenResponse.scopes?.components(separatedBy: " ") else {
                         throw Abort(.unauthorized)
                     }
                     
@@ -67,7 +67,7 @@ extension OAuthHelper {
                         responseActor: responseActor
                     )
                 }
-
+                
                 let remoteTokenResponse = try await responseActor.getRemoteTokenResponse()
                 
                 guard let user = remoteTokenResponse.user else {
@@ -78,7 +78,7 @@ extension OAuthHelper {
             }
         )
     }
-
+    
     private static func setupRemoteTokenResponse(
         request: Request,
         tokenIntrospectionEndpoint: String,
@@ -110,11 +110,11 @@ extension OAuthHelper {
             throw Abort(.unauthorized)
         }
         
-        var scopes: [String]?
+        var scopes: String?
         var oauthUser: OAuthUser?
         
         if let tokenScopes: String = tokenInfoJSON[OAuthResponseParameters.scope] {
-            scopes = tokenScopes.components(separatedBy: " ")
+            scopes = tokenScopes
         }
         
         if let userID: String = tokenInfoJSON[OAuthResponseParameters.userID] {
@@ -133,6 +133,7 @@ extension OAuthHelper {
 }
 
 struct RemoteTokenResponse {
-    let scopes: [String]?
+    let scopes: String?
     let user: OAuthUser?
 }
+

--- a/Sources/VaporOAuth/Helper/OAuthHelper.swift
+++ b/Sources/VaporOAuth/Helper/OAuthHelper.swift
@@ -1,12 +1,12 @@
 import Vapor
 
 public struct OAuthHelper: Sendable {
-    public var assertScopes: @Sendable ([String]?, Request) async throws -> Void
+    public var assertScopes: @Sendable (String?, Request) async throws -> Void
     public var user: @Sendable (Request) async throws -> OAuthUser
 
     public init(
-        assertScopes: @escaping @Sendable ([String]?, Request) async throws -> Void,
-        user: @escaping @Sendable (Request) async throws  -> OAuthUser
+        assertScopes: @escaping @Sendable (String?, Request) async throws -> Void,
+        user: @escaping @Sendable (Request) async throws -> OAuthUser
     ) {
         self.assertScopes = assertScopes
         self.user = user

--- a/Sources/VaporOAuth/Middleware/OAuth2ScopeMiddleware.swift
+++ b/Sources/VaporOAuth/Middleware/OAuth2ScopeMiddleware.swift
@@ -1,13 +1,14 @@
 import Vapor
 
 public struct OAuth2ScopeMiddleware: AsyncMiddleware {
-    let requiredScopes: [String]?
+    let requiredScopes: String?
 
-    public init(requiredScopes: [String]?) {
+    public init(requiredScopes: String?) {
         self.requiredScopes = requiredScopes
     }
 
     public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        // Pass the scopes as a string directly
         try await request.oAuthHelper.assertScopes(requiredScopes, request)
 
         return try await next.respond(to: request)

--- a/Sources/VaporOAuth/Middleware/OAuth2TokenIntrospectionMiddleware.swift
+++ b/Sources/VaporOAuth/Middleware/OAuth2TokenIntrospectionMiddleware.swift
@@ -1,9 +1,9 @@
 import Vapor
 
 public struct OAuth2TokenIntrospectionMiddleware: AsyncMiddleware {
-    let requiredScopes: [String]?
+    let requiredScopes: String?
 
-    public init(requiredScopes: [String]?) {
+    public init(requiredScopes: String?) {
         self.requiredScopes = requiredScopes
     }
 

--- a/Sources/VaporOAuth/Models/OAuthClient.swift
+++ b/Sources/VaporOAuth/Models/OAuthClient.swift
@@ -4,7 +4,7 @@ public struct OAuthClient {
     public let clientID: String
     public let redirectURIs: [String]?
     public let clientSecret: String?
-    public let validScopes: [String]?
+    public let validScopes: String?
     public let confidentialClient: Bool?
     public let firstParty: Bool
     public let allowedGrantType: OAuthFlowType
@@ -15,7 +15,7 @@ public struct OAuthClient {
 
     public var extend: Vapor.Extend = .init()
 
-    public init(clientID: String, redirectURIs: [String]?, clientSecret: String? = nil, validScopes: [String]? = nil,
+    public init(clientID: String, redirectURIs: [String]?, clientSecret: String? = nil, validScopes: String? = nil,
                 confidential: Bool? = nil, firstParty: Bool = false, allowedGrantType: OAuthFlowType,
                 postLogoutRedirectURIs: [String]? = nil, idTokenSignedResponseAlg: String? = "RS256") {
         self.clientID = clientID

--- a/Sources/VaporOAuth/Models/OAuthCode.swift
+++ b/Sources/VaporOAuth/Models/OAuthCode.swift
@@ -6,7 +6,7 @@ public struct OAuthCode {
     public let redirectURI: String
     public let userID: String
     public let expiryDate: Date
-    public let scopes: [String]?
+    public let scopes: String?
 
     // PKCE parameters
     public let codeChallenge: String?
@@ -23,7 +23,7 @@ public struct OAuthCode {
         redirectURI: String,
         userID: String,
         expiryDate: Date,
-        scopes: [String]?,
+        scopes: String?,
         codeChallenge: String?, // Add PKCE parameters
         codeChallengeMethod: String?,
         nonce: String? = nil

--- a/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
+++ b/Sources/VaporOAuth/Models/OAuthDeviceCode.swift
@@ -6,7 +6,7 @@ public struct OAuthDeviceCode {
     public let clientID: String
     public let userID: String?
     public let expiryDate: Date
-    public let scopes: [String]?
+    public let scopes: String? // Updated to String?
 
     public var extend: [String: Any] = [:]
 
@@ -16,7 +16,7 @@ public struct OAuthDeviceCode {
         clientID: String,
         userID: String?,
         expiryDate: Date,
-        scopes: [String]?
+        scopes: String? // Updated to String?
     ) {
         self.deviceCodeID = deviceCodeID
         self.userCode = userCode

--- a/Sources/VaporOAuth/Models/Tokens/AccessToken.swift
+++ b/Sources/VaporOAuth/Models/Tokens/AccessToken.swift
@@ -5,7 +5,7 @@ public protocol AccessToken: JWTPayload {
     var jti: String { get }
     var clientID: String { get }
     var userID: String? { get }
-    var scopes: [String]? { get }
+    var scopes: String? { get }
     var expiryTime: Date { get }
 }
 

--- a/Sources/VaporOAuth/Models/Tokens/RefreshToken.swift
+++ b/Sources/VaporOAuth/Models/Tokens/RefreshToken.swift
@@ -5,7 +5,7 @@ public protocol RefreshToken: JWTPayload {
     var jti: String { get set }
     var clientID: String { get set }
     var userID: String? { get set }
-    var scopes: [String]? { get set }
+    var scopes: String? { get set }
     var exp: Date { get }
 }
 

--- a/Sources/VaporOAuth/Protocols/AuthorizeHandler.swift
+++ b/Sources/VaporOAuth/Protocols/AuthorizeHandler.swift
@@ -41,7 +41,7 @@ public struct AuthorizationRequestObject {
     public let responseType: String
     public let clientID: String
     public let redirectURI: URI
-    public let scope: [String]
+    public let scope: String
     public let state: String?
     public let csrfToken: String
     // PKCE parameters
@@ -50,7 +50,7 @@ public struct AuthorizationRequestObject {
     // OpenID Connect specific parameters
     public let nonce: String?
     
-    public init(responseType: String, clientID: String, redirectURI: URI, scope: [String], state: String?, csrfToken: String, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) {
+    public init(responseType: String, clientID: String, redirectURI: URI, scope: String, state: String?, csrfToken: String, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) {
         self.responseType = responseType
         self.clientID = clientID
         self.redirectURI = redirectURI

--- a/Sources/VaporOAuth/Protocols/CodeManager.swift
+++ b/Sources/VaporOAuth/Protocols/CodeManager.swift
@@ -1,13 +1,13 @@
 /// Responsible for generating and managing OAuth Codes
 public protocol CodeManager: Sendable {
     // Updated to include PKCE parameters
-    func generateCode(userID: String, clientID: String, redirectURI: String, scopes: [String]?, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) async throws -> String
+    func generateCode(userID: String, clientID: String, redirectURI: String, scopes: String?, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) async throws -> String
     func getCode(_ code: String) async throws -> OAuthCode?
 
     // This is explicit to ensure that the code is marked as used or deleted (it could be implied that this is done when you call
     // `getCode` but it is called explicitly to remind developers to ensure that codes can't be reused)
     func codeUsed(_ code: OAuthCode) async throws
-    func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) async throws -> String
+    func generateDeviceCode(userID: String, clientID: String, scopes: String?) async throws -> String
     func getDeviceCode(_ deviceCode: String) async throws -> OAuthDeviceCode?
     func deviceCodeUsed(_ deviceCode: OAuthDeviceCode) async throws
 }

--- a/Sources/VaporOAuth/Protocols/TokenManager.swift
+++ b/Sources/VaporOAuth/Protocols/TokenManager.swift
@@ -5,7 +5,7 @@ public protocol TokenManager: Sendable {
     func generateTokens(
         clientID: String,
         userID: String?,
-        scopes: [String]?,
+        scopes: String?,
         accessTokenExpiryTime: Int,
         idTokenExpiryTime: Int,
         nonce: String?
@@ -15,7 +15,7 @@ public protocol TokenManager: Sendable {
     func generateAccessToken(
         clientID: String,
         userID: String?,
-        scopes: [String]?,
+        scopes: String?,
         expiryTime: Int
     ) async throws -> AccessToken
     
@@ -23,7 +23,7 @@ public protocol TokenManager: Sendable {
     func generateAccessRefreshTokens(
         clientID: String,
         userID: String?,
-        scopes: [String]?,
+        scopes: String?,
         accessTokenExpiryTime: Int
     ) async throws -> (AccessToken, RefreshToken)
     
@@ -34,13 +34,13 @@ public protocol TokenManager: Sendable {
     func getAccessToken(_ accessToken: String) async throws -> AccessToken?
     
     // Updates a refresh token, typically to change its scope.
-    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) async throws
+    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: String) async throws
     
     // Generates an ID token. Should be called after successful authentication.
     func generateIDToken(
         clientID: String,
         userID: String,
-        scopes: [String]?,
+        scopes: String?,
         expiryTime: Int,
         nonce: String?
     ) async throws -> IDToken

--- a/Sources/VaporOAuth/RouteHandlers/AuthorizeGetHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/AuthorizeGetHandler.swift
@@ -101,13 +101,9 @@ struct AuthorizeGetHandler {
             return (try await authorizeHandler.handleAuthorizationError(.invalidRedirectURI), nil)
         }
         
-        let scopes: [String]
-        
-        if let scopeQuery: String = request.query[OAuthRequestParameters.scope] {
-            scopes = scopeQuery.components(separatedBy: " ")
-        } else {
-            scopes = []
-        }
+        // Extract scopes as a single string
+        let scopes: String = request.query[OAuthRequestParameters.scope] ?? ""
+
         
         let state: String? = request.query[OAuthRequestParameters.state]
         
@@ -188,7 +184,7 @@ struct AuthorizeGetHandler {
 struct AuthorizationGetRequestObject {
     let clientID: String
     let redirectURIString: String
-    let scopes: [String]
+    let scopes: String
     let state: String?
     let responseType: String
     let codeChallenge: String?

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/AuthCodeTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/AuthCodeTokenHandler.swift
@@ -46,7 +46,6 @@ struct AuthCodeTokenHandler {
         try await codeManager.codeUsed(code)
         
         let scopes = code.scopes
-        // Check for 'openid' scope to determine if it's an OpenID Connect request
         let isOpenIDConnectFlow = scopes?.contains("openid") ?? false
         let expiryTime = 3600
         
@@ -60,7 +59,7 @@ struct AuthCodeTokenHandler {
                 nonce: code.nonce
             )
             
-            return try await tokenResponseGenerator.createOpenIDConnectResponse(accessToken: access, refreshToken: refresh, idToken: idToken, expires: Int(expiryTime), scope: scopes?.joined(separator: " "))
+            return try await tokenResponseGenerator.createOpenIDConnectResponse(accessToken: access, refreshToken: refresh, idToken: idToken, expires: Int(expiryTime), scope: scopes)
             
         } else {
             let (access, refresh) = try await tokenManager.generateAccessRefreshTokens(
@@ -70,7 +69,7 @@ struct AuthCodeTokenHandler {
                 accessTokenExpiryTime: expiryTime
             )
             
-            return try await tokenResponseGenerator.createResponse(accessToken: access, refreshToken: refresh, expires: Int(expiryTime), scope: scopes?.joined(separator: " "))
+            return try await tokenResponseGenerator.createResponse(accessToken: access, refreshToken: refresh, expires: Int(expiryTime), scope: scopes)
         }
     }
 }

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/DeviceCodeTokenHandler.swift
@@ -8,24 +8,24 @@
 import Vapor
 
 struct DeviceCodeTokenHandler {
-
+    
     let clientValidator: ClientValidator
     let scopeValidator: ScopeValidator
     let codeManager: CodeManager
     let tokenManager: TokenManager
     let tokenResponseGenerator: TokenResponseGenerator
-
+    
     func handleDeviceCodeTokenRequest(_ request: Request) async throws -> Response {
         guard let deviceCodeString: String = request.content[OAuthRequestParameters.deviceCode] else {
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
                                                              description: "Request was missing the 'device_code' parameter")
         }
-
+        
         guard let clientID: String = request.content[OAuthRequestParameters.clientID] else {
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
                                                              description: "Request was missing the 'client_id' parameter")
         }
-
+        
         do {
             try await clientValidator.authenticateClient(clientID: clientID, clientSecret: nil,
                                                          grantType: .deviceCode)
@@ -33,40 +33,40 @@ struct DeviceCodeTokenHandler {
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidClient,
                                                              description: "Request had invalid client credentials", status: .unauthorized)
         }
-
+        
         guard let deviceCode = try await codeManager.getDeviceCode(deviceCodeString) else {
             let errorDescription = "The device code provided was invalid or expired"
             return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidGrant,
                                                              description: errorDescription)
         }
-
+        
         if deviceCode.expiryDate < Date() {
             let errorDescription = "The device code provided was invalid or expired"
             return try tokenResponseGenerator.createResponse(error: "expired_token",
                                                              description: errorDescription)
         }
-
-        if let scopes = deviceCode.scopes {
+        
+        let scopesString = deviceCode.scopes // Scopes are now a String?
+        if let scopesString = scopesString {
             do {
-                let scopesString = scopes.joined(separator: " ")
                 try await scopeValidator.validateScope(clientID: clientID, scopes: scopesString)
             } catch ScopeError.invalid, ScopeError.unknown {
                 return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
                                                                  description: "Request contained an invalid or unknown scope")
             }
         }
-
+        
         try await codeManager.deviceCodeUsed(deviceCode)
-
+        
         let expiryTime = 3600
-
+        
         let (access, refresh) = try await tokenManager.generateAccessRefreshTokens(
             clientID: clientID, userID: deviceCode.userID,
-            scopes: deviceCode.scopes,
+            scopes: scopesString, // Pass scopeString directly
             accessTokenExpiryTime: expiryTime
         )
-
+        
         return try await tokenResponseGenerator.createResponse(accessToken: access, refreshToken: refresh, expires: Int(expiryTime),
-                                                         scope: deviceCode.scopes?.joined(separator: " "))
+                                                               scope: scopesString) // Use scopeString here as well
     }
 }

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
@@ -1,31 +1,29 @@
 import Vapor
 
 struct RefreshTokenHandler {
-
+    
     let scopeValidator: ScopeValidator
     let tokenManager: TokenManager
     let clientValidator: ClientValidator
     let tokenAuthenticator: TokenAuthenticator
     let tokenResponseGenerator: TokenResponseGenerator
-
+    
     func handleRefreshTokenRequest(_ request: Request) async throws -> Response {
-
+        
         let (errorResponseReturned, refreshTokenRequestReturned) = try await validateRefreshTokenRequest(request)
-
+        
         if let errorResponse = errorResponseReturned {
             return errorResponse
         }
-
+        
         guard let refreshTokenRequest = refreshTokenRequestReturned else {
             throw Abort(.internalServerError)
         }
-
-        let scopesString: String? = request.content[OAuthRequestParameters.scope]
-        var scopesRequested = scopesString?.components(separatedBy: " ")
-
-        if let scopes = scopesRequested {
+        
+        var scopesString: String? = request.content[OAuthRequestParameters.scope]
+        
+        if let scopesString = scopesString {
             do {
-                let scopesString = scopes.joined(separator: " ")
                 try await scopeValidator.validateScope(clientID: refreshTokenRequest.clientID, scopes: scopesString)
             } catch ScopeError.invalid {
                 return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
@@ -34,10 +32,13 @@ struct RefreshTokenHandler {
                 return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
                                                                  description: "Request contained an unknown scope")
             }
-
-            if let tokenScopes = refreshTokenRequest.refreshToken.scopes {
-                for scope in scopes {
-                    if !tokenScopes.contains(scope) {
+            
+            if let tokenScopesString = refreshTokenRequest.refreshToken.scopes {
+                let tokenScopesArray = tokenScopesString.components(separatedBy: " ")
+                let requestedScopesArray = scopesString.components(separatedBy: " ")
+                
+                for scope in requestedScopesArray {
+                    if !tokenScopesArray.contains(scope) {
                         return try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidScope,
                                                                          description: "Request contained elevated scopes")
                     }
@@ -48,39 +49,46 @@ struct RefreshTokenHandler {
                     description: "Request contained elevated scopes"
                 )
             }
-
-            try await tokenManager.updateRefreshToken(refreshTokenRequest.refreshToken, scopes: scopes)
+            
+            try await tokenManager.updateRefreshToken(refreshTokenRequest.refreshToken, scopes: scopesString)
         } else {
-            scopesRequested = refreshTokenRequest.refreshToken.scopes
+            // No new scopes requested, use the scopes from the existing refresh token
+            scopesString = refreshTokenRequest.refreshToken.scopes
         }
-
+        
+        
         let expiryTime = 3600
-        let accessToken  = try await tokenManager.generateAccessRefreshTokens(
+        let accessToken = try await tokenManager.generateAccessRefreshTokens(
             clientID: refreshTokenRequest.clientID,
             userID: refreshTokenRequest.refreshToken.userID,
-            scopes: scopesRequested, accessTokenExpiryTime: expiryTime
+            scopes: scopesString,
+            accessTokenExpiryTime: expiryTime
         )
-
-        return try await tokenResponseGenerator.createResponse(accessToken: accessToken.0, refreshToken: accessToken.1,
-                                                         expires: expiryTime, scope: scopesString)
+        
+        return try await tokenResponseGenerator.createResponse(
+            accessToken: accessToken.0,
+            refreshToken: accessToken.1,
+            expires: expiryTime,
+            scope: scopesString
+        )
     }
-
+    
     private func validateRefreshTokenRequest(_ request: Request) async throws -> (Response?, RefreshTokenRequest?) {
         guard let clientID: String = request.content[OAuthRequestParameters.clientID] else {
             let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
                                                                           description: "Request was missing the 'client_id' parameter")
             return (errorResponse, nil)
         }
-
+        
         guard let clientSecret: String = request.content[OAuthRequestParameters.clientSecret] else {
             let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
                                                                           description: "Request was missing the 'client_secret' parameter")
             return (errorResponse, nil)
         }
-
+        
         do {
             try await clientValidator.authenticateClient(clientID: clientID, clientSecret: clientSecret,
-                                                   grantType: nil, checkConfidentialClient: true)
+                                                         grantType: nil, checkConfidentialClient: true)
         } catch ClientError.unauthorized {
             let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidClient,
                                                                           description: "Request had invalid client credentials",
@@ -92,20 +100,20 @@ struct RefreshTokenHandler {
                                                                           description: errorDescription)
             return (errorResponse, nil)
         }
-
+        
         guard let refreshTokenString: String = request.content[OAuthRequestParameters.refreshToken] else {
             let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidRequest,
                                                                           description: "Request was missing the 'refresh_token' parameter")
             return (errorResponse, nil)
         }
-
+        
         guard let refreshToken = try await tokenManager.getRefreshToken(refreshTokenString),
-            tokenAuthenticator.validateRefreshToken(refreshToken, clientID: clientID) else {
-                let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidGrant,
-                                                                              description: "The refresh token is invalid")
-                return (errorResponse, nil)
+              tokenAuthenticator.validateRefreshToken(refreshToken, clientID: clientID) else {
+            let errorResponse = try tokenResponseGenerator.createResponse(error: OAuthResponseParameters.ErrorType.invalidGrant,
+                                                                          description: "The refresh token is invalid")
+            return (errorResponse, nil)
         }
-
+        
         let refreshTokenRequest = RefreshTokenRequest(clientID: clientID, clientSecret: clientSecret, refreshToken: refreshToken)
         return (nil, refreshTokenRequest)
     }

--- a/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenHandlers/RefreshTokenHandler.swift
@@ -21,7 +21,7 @@ struct RefreshTokenHandler {
         }
 
         let scopesString: String? = request.content[OAuthRequestParameters.scope]
-        var scopesRequested = scopesString?.components(separatedBy: " ")
+        var scopesRequested: [String]? = scopesString?.components(separatedBy: " ")
 
         if let scopes = scopesRequested {
             do {
@@ -51,7 +51,7 @@ struct RefreshTokenHandler {
 
             try await tokenManager.updateRefreshToken(refreshTokenRequest.refreshToken, scopes: scopes)
         } else {
-            scopesRequested = refreshTokenRequest.refreshToken.scopes
+            scopesRequested = refreshTokenRequest.refreshToken.scopes?.components(separatedBy: " ")
         }
 
         let expiryTime = 3600

--- a/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
@@ -28,7 +28,8 @@ struct TokenIntrospectionHandler {
             return try createTokenResponse(active: false, expiryDate: nil, clientID: nil)
         }
 
-        let scopes = token.scopes?.joined(separator: " ")
+        let scopes = token.scopes
+        
         var user: OAuthUser? = nil
 
         if let userID = token.userID {

--- a/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
@@ -28,8 +28,7 @@ struct TokenIntrospectionHandler {
             return try createTokenResponse(active: false, expiryDate: nil, clientID: nil)
         }
 
-        let scopes = token.scopes
-        
+        let scopes = token.scopes 
         var user: OAuthUser? = nil
 
         if let userID = token.userID {

--- a/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/TokenIntrospectionHandler.swift
@@ -28,7 +28,7 @@ struct TokenIntrospectionHandler {
             return try createTokenResponse(active: false, expiryDate: nil, clientID: nil)
         }
 
-        let scopes = token.scopes?.joined(separator: " ")
+        let scopes = token.scopes 
         var user: OAuthUser? = nil
 
         if let userID = token.userID {

--- a/Sources/VaporOAuth/Utilities/TokenAuthenticator.swift
+++ b/Sources/VaporOAuth/Utilities/TokenAuthenticator.swift
@@ -10,17 +10,21 @@ public struct TokenAuthenticator {
         return true
     }
 
-    func validateAccessToken(_ accessToken: AccessToken, requiredScopes: [String]?) -> Bool {
-        guard let scopes = requiredScopes else {
+    func validateAccessToken(_ accessToken: AccessToken, requiredScopes: String?) -> Bool {
+        guard let requiredScopesString = requiredScopes else {
             return true
         }
 
-        guard let accessTokenScopes = accessToken.scopes else {
+        let requiredScopesArray = requiredScopesString.components(separatedBy: " ")
+
+        guard let accessTokenScopesString = accessToken.scopes else {
             return false
         }
 
-        for scope in scopes {
-            if !accessTokenScopes.contains(scope) {
+        let accessTokenScopesArray = accessTokenScopesString.components(separatedBy: " ")
+
+        for scope in requiredScopesArray {
+            if !accessTokenScopesArray.contains(scope) {
                 return false
             }
         }

--- a/Sources/VaporOAuth/Validators/ClientValidator.swift
+++ b/Sources/VaporOAuth/Validators/ClientValidator.swift
@@ -6,7 +6,7 @@ struct ClientValidator {
     let scopeValidator: ScopeValidator
     let environment: Environment
     
-    func validateClient(clientID: String, responseType: String, redirectURI: String, scopes: [String]?) async throws {
+    func validateClient(clientID: String, responseType: String, redirectURI: String, scopes: String?) async throws {
         guard let client = try await clientRetriever.getClient(clientID: clientID) else {
             throw AuthorizationError.invalidClientID
         }
@@ -37,7 +37,7 @@ struct ClientValidator {
             throw AuthorizationError.invalidResponseType
         }
         
-        let scopesString = scopes?.joined(separator: " ")
+        let scopesString = scopes
         
         try await scopeValidator.validateScope(clientID: clientID, scopes: scopesString)
         

--- a/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationRequestTests.swift
+++ b/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationRequestTests.swift
@@ -215,7 +215,7 @@ class AuthorizationRequestTests: XCTestCase {
         )
 
         // Check if the response is an error response indicating the missing codeChallengeMethod
-        XCTAssertEqual(response.status, .seeOther) // Assuming error responses are redirected
+        XCTAssertEqual(response.status, .seeOther)
         XCTAssertTrue(response.headers.first(name: .location)?.contains("error=") ?? false)
     }
     
@@ -303,7 +303,7 @@ class AuthorizationRequestTests: XCTestCase {
     
     func testThatClientAccessingScopeItShouldNotReturnsInvalidScopeError() async throws {
         let clientID = "ABCDEFGH"
-        let scopes = ["email", "profile", "admin"]
+        let scopes = "email profile admin"
         let invalidScope = "create"
         let scopeClient = OAuthClient(
             clientID: clientID,

--- a/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
+++ b/Tests/VaporOAuthTests/AuthorizationTests/AuthorizationResponseTests.swift
@@ -30,7 +30,7 @@ class AuthorizationResponseTests: XCTestCase {
         let oauthClient = OAuthClient(
             clientID: AuthorizationResponseTests.clientID,
             redirectURIs: [AuthorizationResponseTests.redirectURI],
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             allowedGrantType: .authorization
         )
         fakeClientRetriever.validClients[AuthorizationResponseTests.clientID] = oauthClient
@@ -215,15 +215,14 @@ class AuthorizationResponseTests: XCTestCase {
     func testThatCorrectScopesSetOnCodeIfSupplied() async throws {
         let scope1 = "email"
         let scope2 = "address"
-        _ = try await getAuthResponse(scope: "\(scope1)+\(scope2)")
+        _ = try await getAuthResponse(scope: "\(scope1) \(scope2)") // Use space as the delimiter
 
         guard let code = fakeCodeManager.getCode(fakeCodeManager.generatedCode) else {
             XCTFail()
             return
         }
 
-        XCTAssertEqual(code.scopes ?? [], [scope1, scope2])
-
+        XCTAssertEqual(code.scopes, "\(scope1) \(scope2)") // Compare as a single string
     }
 
     func testThatRedirectURISetOnCodeCorrectly() async throws {

--- a/Tests/VaporOAuthTests/DefaultImplementationTests/DefaultImplementationTests.swift
+++ b/Tests/VaporOAuthTests/DefaultImplementationTests/DefaultImplementationTests.swift
@@ -42,7 +42,7 @@ class DefaultImplementationTests: XCTestCase {
             responseType: "token",
             clientID: "client-ID",
             redirectURI: uri,
-            scope: ["email"],
+            scope: "email",
             state: "abcdef",
             csrfToken: "01234",
             codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",

--- a/Tests/VaporOAuthTests/Fakes/AccessToken.swift
+++ b/Tests/VaporOAuthTests/Fakes/AccessToken.swift
@@ -5,10 +5,10 @@ struct FakeAccessToken: AccessToken {
     let jti: String
     let clientID: String
     let userID: String?
-    let scopes: [String]?
+    let scopes: String?
     let expiryTime: Date
 
-    init(jti: String, clientID: String, userID: String? = nil, scopes: [String]? = nil, expiryTime: Date) {
+    init(jti: String, clientID: String, userID: String? = nil, scopes: String? = nil, expiryTime: Date) {
         self.jti = jti
         self.clientID = clientID
         self.userID = userID

--- a/Tests/VaporOAuthTests/Fakes/CapturingAuthorizeHandler.swift
+++ b/Tests/VaporOAuthTests/Fakes/CapturingAuthorizeHandler.swift
@@ -6,7 +6,7 @@ class CapturingAuthoriseHandler: AuthorizeHandler {
     private(set) var responseType: String?
     private(set) var clientID: String?
     private(set) var redirectURI: URI?
-    private(set) var scope: [String]?
+    private(set) var scope: String?
     private(set) var state: String?
     private(set) var csrfToken: String?
     // Add PKCE parameters

--- a/Tests/VaporOAuthTests/Fakes/FakeCodeManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeCodeManager.swift
@@ -17,13 +17,13 @@ class FakeCodeManager: CodeManager {
     }
     
     // Updated to include PKCE parameters
-    func generateCode(userID: String, clientID: String, redirectURI: String, scopes: [String]?, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) throws -> String {
+    func generateCode(userID: String, clientID: String, redirectURI: String, scopes: String?, codeChallenge: String?, codeChallengeMethod: String?, nonce: String?) throws -> String {
         let code = OAuthCode(codeID: generatedCode, clientID: clientID, redirectURI: redirectURI, userID: userID, expiryDate: Date().addingTimeInterval(60), scopes: scopes, codeChallenge: codeChallenge, codeChallengeMethod: codeChallengeMethod)
         codes[generatedCode] = code
         return generatedCode
     }
 
-    func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) throws -> String {
+    func generateDeviceCode(userID: String, clientID: String, scopes: String?) throws -> String {
         let deviceCode = OAuthDeviceCode(deviceCodeID: generatedCode, userCode: "USER_CODE", clientID: clientID, userID: userID, expiryDate: Date().addingTimeInterval(60), scopes: scopes)
         deviceCodes[generatedCode] = deviceCode
         return generatedCode

--- a/Tests/VaporOAuthTests/Fakes/FakeKeyManagementService.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeKeyManagementService.swift
@@ -5,34 +5,93 @@ import Crypto
 
 class FakeKeyManagementService: KeyManagementService {
     
-    func privateKeyIdentifier() throws -> String {
-        return ""
+    private var keys = [String: Data]()
+    private var currentPublicKeyId: String?
+    private var currentPrivateKeyId: String?
+    
+    func generateKey() async throws -> (privateKeyIdentifier: String, publicKeyIdentifier: String) {
+        let privateKeyId = UUID().uuidString
+        let publicKeyId = UUID().uuidString
+        
+        // Fake keys
+        keys[privateKeyId] = Data("fake_private_key".utf8)
+        keys[publicKeyId] = Data("fake_public_key".utf8)
+        
+        currentPrivateKeyId = privateKeyId
+        currentPublicKeyId = publicKeyId
+        
+        return (privateKeyIdentifier: privateKeyId, publicKeyIdentifier: publicKeyId)
     }
     
-    func generateKey() throws -> RSAKey {
-        // Not required for HMAC based implementation
-        fatalError("generateKey() should not be called in FakeKeyManagementService")
+    func storeKey(_ key: String, keyType: KeyType) async throws {
+        let keyId = UUID().uuidString
+        keys[keyId] = Data(key.utf8)
+        if keyType == .private {
+            currentPrivateKeyId = keyId
+        } else {
+            currentPublicKeyId = keyId
+        }
     }
     
-    func storeKey(_ key: RSAKey) throws {
-        // Not required for HMAC based implementation
-        fatalError("storeKey(_:) should not be called in FakeKeyManagementService")
+    func retrieveKey(identifier: String, keyType: KeyType) async throws -> Data {
+        guard let key = keys[identifier] else {
+            throw NSError(domain: "FakeKeyManagementService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Key not found"])
+        }
+        return key
     }
     
-    func retrieveKey(identifier: String) throws -> RSAKey {
-        // Not required for HMAC based implementation
-        fatalError("retrieveKey(identifier:) should not be called in FakeKeyManagementService")
+    func publicKeyIdentifier() async throws -> String {
+        guard let publicKeyId = currentPublicKeyId else {
+            throw NSError(domain: "FakeKeyManagementService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Public key not set"])
+        }
+        return publicKeyId
     }
     
-    func publicKeyIdentifier() throws -> String {
-        // Not required for HMAC based implementation
-        fatalError("publicKeyIdentifier() should not be called in FakeKeyManagementService")
+    func privateKeyIdentifier() async throws -> String {
+        guard let privateKeyId = currentPrivateKeyId else {
+            throw NSError(domain: "FakeKeyManagementService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Private key not set"])
+        }
+        return privateKeyId
     }
     
-    func convertToJWK(_ key: RSAKey) throws -> JWK {
-        // Creating a dummy RSA JWK with arbitrary modulus and exponent values
-        let dummyModulus = "dummyModulus" // Base64 encoded string
-        let dummyExponent = "dummyExponent" // Base64 encoded string
-        return JWK.rsa(.rs256, identifier: nil, modulus: dummyModulus, exponent: dummyExponent)
+    func rotateKey(deprecateOld: Bool) async throws {
+        // Create a new key pair
+        let newKeys = try await generateKey()
+        
+        if deprecateOld {
+            // Deprecate old keys
+            if let oldPrivateKeyId = currentPrivateKeyId {
+                keys.removeValue(forKey: oldPrivateKeyId)
+            }
+            if let oldPublicKeyId = currentPublicKeyId {
+                keys.removeValue(forKey: oldPublicKeyId)
+            }
+        }
+        
+        currentPrivateKeyId = newKeys.privateKeyIdentifier
+        currentPublicKeyId = newKeys.publicKeyIdentifier
+    }
+    
+    func deleteKey(identifier: String) async throws {
+        keys.removeValue(forKey: identifier)
+    }
+    
+    func listKeys() async throws -> [String] {
+        return Array(keys.keys)
+    }
+    
+    func convertToJWK(_ publicKey: Data) throws -> [JWTKit.JWK] {
+        // Assuming that publicKey data can be converted to the necessary components
+        // for an ECDSA key. You'll need to adjust this to suit your actual key format.
+        // This is just an illustrative example.
+        
+        let keyIdentifier = JWKIdentifier(string: "test") // Generate a unique identifier
+        let xCoordinate = "your_x_coordinate" // Replace with actual x coordinate in base64 URL encoded string
+        let yCoordinate = "your_y_coordinate" // Replace with actual y coordinate in base64 URL encoded string
+        let curve = ECDSAKey.Curve.p256 // Replace with actual curve type if different
+        
+        let jwk = JWK.ecdsa(.es256, identifier: keyIdentifier, x: xCoordinate, y: yCoordinate, curve: curve)
+        
+        return [jwk]
     }
 }

--- a/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
@@ -26,7 +26,7 @@ struct MyIDToken: VaporOAuth.IDToken {
 
 class FakeTokenManager: TokenManager {
     
-    func generateTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
+    func generateTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
         // Generate access token
         let accessToken = try generateAccessToken(clientID: clientID, userID: userID, scopes: scopes, expiryTime: accessTokenExpiryTime)
         
@@ -39,7 +39,7 @@ class FakeTokenManager: TokenManager {
         return (accessToken, refreshToken, idToken)
     }
     
-    func generateIDToken(clientID: String, userID: String, scopes: [String]?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
+    func generateIDToken(clientID: String, userID: String, scopes: String?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
         // Create an instance of your IDToken conforming object and set its properties
         var idToken = MyIDToken()
         idToken.jti = "YOUR-ID-TOKEN-STRING"
@@ -69,12 +69,9 @@ class FakeTokenManager: TokenManager {
         return accessTokens[accessToken]
     }
     
-    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
-        // Convert scopes array to a single string, separated by spaces, or nil if scopes is nil
-        let scopesString = scopes?.joined(separator: " ")
-        
-        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
-        let refreshToken = FakeRefreshToken(jti: refreshTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, exp: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
+    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
+        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
+        let refreshToken = FakeRefreshToken(jti: refreshTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, exp: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
         
         accessTokens[accessTokenToReturn] = accessToken
         refreshTokens[refreshTokenToReturn] = refreshToken
@@ -82,14 +79,13 @@ class FakeTokenManager: TokenManager {
         return (accessToken, refreshToken)
     }
     
-    func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
-        let scopesString = scopes?.joined(separator: " ")
-        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: currentTime.addingTimeInterval(TimeInterval(expiryTime)))
+    func generateAccessToken(clientID: String, userID: String?, scopes: String?, expiryTime: Int) throws -> AccessToken {
+        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(expiryTime)))
         accessTokens[accessTokenToReturn] = accessToken
         return accessToken
     }
     
-    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) {
+    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: String) {
         var tempRefreshToken = refreshToken
         tempRefreshToken.scopes = scopes.joined(separator: " ")
         refreshTokens[refreshToken.jti] = tempRefreshToken

--- a/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
@@ -26,7 +26,7 @@ struct MyIDToken: VaporOAuth.IDToken {
 
 class FakeTokenManager: TokenManager {
     
-    func generateTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
+    func generateTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
         // Generate access token
         let accessToken = try generateAccessToken(clientID: clientID, userID: userID, scopes: scopes, expiryTime: accessTokenExpiryTime)
         
@@ -39,7 +39,7 @@ class FakeTokenManager: TokenManager {
         return (accessToken, refreshToken, idToken)
     }
     
-    func generateIDToken(clientID: String, userID: String, scopes: [String]?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
+    func generateIDToken(clientID: String, userID: String, scopes: String?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
         // Create an instance of your IDToken conforming object and set its properties
         var idToken = MyIDToken()
         idToken.jti = "YOUR-ID-TOKEN-STRING"
@@ -69,7 +69,7 @@ class FakeTokenManager: TokenManager {
         return accessTokens[accessToken]
     }
     
-    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
+    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
         let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
         let refreshToken = FakeRefreshToken(jti: refreshTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, exp: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
         
@@ -78,13 +78,13 @@ class FakeTokenManager: TokenManager {
         return (accessToken, refreshToken)
     }
     
-    func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
+    func generateAccessToken(clientID: String, userID: String?, scopes: String?, expiryTime: Int) throws -> AccessToken {
         let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(expiryTime)))
         accessTokens[accessTokenToReturn] = accessToken
         return accessToken
     }
     
-    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) {
+    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: String) {
         var tempRefreshToken = refreshToken
         tempRefreshToken.scopes = scopes
         refreshTokens[refreshToken.jti] = tempRefreshToken

--- a/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeTokenManager.swift
@@ -70,23 +70,28 @@ class FakeTokenManager: TokenManager {
     }
     
     func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
-        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
-        let refreshToken = FakeRefreshToken(jti: refreshTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, exp: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
+        // Convert scopes array to a single string, separated by spaces, or nil if scopes is nil
+        let scopesString = scopes?.joined(separator: " ")
+        
+        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
+        let refreshToken = FakeRefreshToken(jti: refreshTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, exp: currentTime.addingTimeInterval(TimeInterval(accessTokenExpiryTime)))
         
         accessTokens[accessTokenToReturn] = accessToken
         refreshTokens[refreshTokenToReturn] = refreshToken
+        
         return (accessToken, refreshToken)
     }
     
     func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
-        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopes, expiryTime: currentTime.addingTimeInterval(TimeInterval(expiryTime)))
+        let scopesString = scopes?.joined(separator: " ")
+        let accessToken = FakeAccessToken(jti: accessTokenToReturn, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: currentTime.addingTimeInterval(TimeInterval(expiryTime)))
         accessTokens[accessTokenToReturn] = accessToken
         return accessToken
     }
     
     func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) {
         var tempRefreshToken = refreshToken
-        tempRefreshToken.scopes = scopes
+        tempRefreshToken.scopes = scopes.joined(separator: " ")
         refreshTokens[refreshToken.jti] = tempRefreshToken
     }
     

--- a/Tests/VaporOAuthTests/Fakes/RefreshToken.swift
+++ b/Tests/VaporOAuthTests/Fakes/RefreshToken.swift
@@ -5,6 +5,6 @@ public struct FakeRefreshToken: RefreshToken {
     public var jti: String
     public var clientID: String
     public var userID: String?
-    public var scopes: [String]?
+    public var scopes: String?
     public var exp: Date
 }

--- a/Tests/VaporOAuthTests/Fakes/StubCodeManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/StubCodeManager.swift
@@ -9,7 +9,7 @@ class StubCodeManager: CodeManager {
         userID: String,
         clientID: String,
         redirectURI: String,
-        scopes: [String]?,
+        scopes: String?,
         codeChallenge: String?,
         codeChallengeMethod: String?,
         nonce: String?
@@ -30,7 +30,7 @@ class StubCodeManager: CodeManager {
         return nil
     }
     
-    func generateDeviceCode(userID: String, clientID: String, scopes: [String]?) throws -> String {
+    func generateDeviceCode(userID: String, clientID: String, scopes: String?) throws -> String {
         
         return "DEVICE_CODE"
     }

--- a/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class StubTokenManager: TokenManager {
     
-    func generateTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
+    func generateTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
         // Generate access and refresh tokens
         let (accessToken, refreshToken) = try generateAccessRefreshTokens(clientID: clientID, userID: userID, scopes: scopes, accessTokenExpiryTime: accessTokenExpiryTime)
         
@@ -13,7 +13,7 @@ class StubTokenManager: TokenManager {
         return (accessToken, refreshToken, idToken)
     }
     
-    func generateIDToken(clientID: String, userID: String, scopes: [String]?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
+    func generateIDToken(clientID: String, userID: String, scopes: String?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
         // Create an instance of your custom IDToken struct and set its properties
         var idToken = MyIDToken()
         idToken.jti = "YOUR-ID-TOKEN-STRING"
@@ -23,7 +23,6 @@ class StubTokenManager: TokenManager {
         idToken.exp = Date().addingTimeInterval(TimeInterval(expiryTime))
         idToken.iat = Date()
         idToken.nonce = nonce
-    
         return idToken
     }
     
@@ -32,13 +31,13 @@ class StubTokenManager: TokenManager {
     var refreshToken = "GHIJKL"
     var deviceCodes: [String: OAuthDeviceCode] = [:]
     
-    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
+    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
         let access = FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
         let refresh = FakeRefreshToken(jti: refreshToken, clientID: clientID, userID: nil, scopes: scopes, exp: Date())
         return (access, refresh)
     }
     
-    func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
+    func generateAccessToken(clientID: String, userID: String?, scopes: String?, expiryTime: Int) throws -> AccessToken {
         return FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
     }
     
@@ -50,6 +49,6 @@ class StubTokenManager: TokenManager {
         return nil
     }
     
-    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) {
+    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: String) {
     }
 }

--- a/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
@@ -33,13 +33,15 @@ class StubTokenManager: TokenManager {
     var deviceCodes: [String: OAuthDeviceCode] = [:]
     
     func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
-        let access = FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
-        let refresh = FakeRefreshToken(jti: refreshToken, clientID: clientID, userID: nil, scopes: scopes, exp: Date())
+        let scopesString = scopes?.joined(separator: " ")
+        let access = FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: Date())
+        let refresh = FakeRefreshToken(jti: refreshToken, clientID: clientID, userID: nil, scopes: scopesString, exp: Date())
         return (access, refresh)
     }
     
     func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
-        return FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
+        let scopesString = scopes?.joined(separator: " ")
+        return FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: Date())
     }
     
     func getRefreshToken(_ refreshToken: String) -> RefreshToken? {

--- a/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
+++ b/Tests/VaporOAuthTests/Fakes/StubTokenManager.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class StubTokenManager: TokenManager {
     
-    func generateTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
+    func generateTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int, idTokenExpiryTime: Int, nonce: String?) async throws -> (VaporOAuth.AccessToken, VaporOAuth.RefreshToken, VaporOAuth.IDToken) {
         // Generate access and refresh tokens
         let (accessToken, refreshToken) = try generateAccessRefreshTokens(clientID: clientID, userID: userID, scopes: scopes, accessTokenExpiryTime: accessTokenExpiryTime)
         
@@ -13,7 +13,7 @@ class StubTokenManager: TokenManager {
         return (accessToken, refreshToken, idToken)
     }
     
-    func generateIDToken(clientID: String, userID: String, scopes: [String]?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
+    func generateIDToken(clientID: String, userID: String, scopes: String?, expiryTime: Int, nonce: String?) async throws -> VaporOAuth.IDToken {
         // Create an instance of your custom IDToken struct and set its properties
         var idToken = MyIDToken()
         idToken.jti = "YOUR-ID-TOKEN-STRING"
@@ -23,7 +23,6 @@ class StubTokenManager: TokenManager {
         idToken.exp = Date().addingTimeInterval(TimeInterval(expiryTime))
         idToken.iat = Date()
         idToken.nonce = nonce
-    
         return idToken
     }
     
@@ -32,16 +31,14 @@ class StubTokenManager: TokenManager {
     var refreshToken = "GHIJKL"
     var deviceCodes: [String: OAuthDeviceCode] = [:]
     
-    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: [String]?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
-        let scopesString = scopes?.joined(separator: " ")
-        let access = FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: Date())
-        let refresh = FakeRefreshToken(jti: refreshToken, clientID: clientID, userID: nil, scopes: scopesString, exp: Date())
+    func generateAccessRefreshTokens(clientID: String, userID: String?, scopes: String?, accessTokenExpiryTime: Int) throws -> (AccessToken, RefreshToken) {
+        let access = FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
+        let refresh = FakeRefreshToken(jti: refreshToken, clientID: clientID, userID: nil, scopes: scopes, exp: Date())
         return (access, refresh)
     }
     
-    func generateAccessToken(clientID: String, userID: String?, scopes: [String]?, expiryTime: Int) throws -> AccessToken {
-        let scopesString = scopes?.joined(separator: " ")
-        return FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopesString, expiryTime: Date())
+    func generateAccessToken(clientID: String, userID: String?, scopes: String?, expiryTime: Int) throws -> AccessToken {
+        return FakeAccessToken(jti: accessToken, clientID: clientID, userID: userID, scopes: scopes, expiryTime: Date())
     }
     
     func getRefreshToken(_ refreshToken: String) -> RefreshToken? {
@@ -52,6 +49,6 @@ class StubTokenManager: TokenManager {
         return nil
     }
     
-    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: [String]) {
+    func updateRefreshToken(_ refreshToken: RefreshToken, scopes: String) {
     }
 }

--- a/Tests/VaporOAuthTests/GrantTests/AuthorizationCodeTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/AuthorizationCodeTokenTests.swift
@@ -39,7 +39,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
     let testClientSecret = "ABCDEFGHIJK"
     let testCodeID = "12345ABCD"
     let userID = "the-user-id"
-    let scopes = ["email", "create"]
+    let scopes = "email create"
     let testCodeChallenge = "testCodeChallenge"
     let testCodeChallengeMethod = "S256"
 
@@ -212,7 +212,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             redirectURI: "https://test.redirect.uri",
             userID: "testUserID",
             expiryDate: Date().addingTimeInterval(3600), // 1 hour in the future
-            scopes: ["testScope"],
+            scopes: "testScope",
             codeChallenge: nil, // No code challenge
             codeChallengeMethod: nil
         )
@@ -241,7 +241,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             redirectURI: "https://test.redirect.uri",
             userID: "testUserID",
             expiryDate: Date().addingTimeInterval(3600), // 1 hour in the future
-            scopes: ["testScope"],
+            scopes: "testScope",
             codeChallenge: codeChallenge, // Provided code challenge
             codeChallengeMethod: "S256"
         )
@@ -319,8 +319,8 @@ class AuthorizationCodeTokenTests: XCTestCase {
     func testThatCorrectResponseReceivedWhenCorrectRequestSent() async throws {
         let accessToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         let refreshToken = "01234567890"
+        let scopes = "email create"  // Defined as a space-delimited string
 
-        
         fakeTokenManager.accessTokenToReturn = accessToken
         fakeTokenManager.refreshTokenToReturn = refreshToken
 
@@ -335,14 +335,15 @@ class AuthorizationCodeTokenTests: XCTestCase {
         XCTAssertEqual(responseJSON.expiresIn, 3600)
         XCTAssertEqual(responseJSON.accessToken, accessToken)
         XCTAssertEqual(responseJSON.refreshToken, refreshToken)
-        XCTAssertEqual(responseJSON.scope, "email create")
+        XCTAssertEqual(responseJSON.scope, scopes)
 
         guard let token = fakeTokenManager.getAccessToken(accessToken) else {
             XCTFail()
             return
         }
 
-        XCTAssertEqual(token.scopes ?? [], scopes)
+        // Directly compare the string values of scopes
+        XCTAssertEqual(token.scopes, scopes)
     }
 
     func testThatNoScopeReturnedIfNoneSetOnCode() async throws {
@@ -405,7 +406,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
         let accessTokenString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         fakeTokenManager.accessTokenToReturn = accessTokenString
         let newCodeString = "new-code-string"
-        let scopes = ["oneScope", "aDifferentScope"]
+        let scopes = "oneScope aDifferentScope"
         let newCode = OAuthCode(codeID: newCodeString, clientID: testClientID, redirectURI: testClientRedirectURI, userID: "user-id", expiryDate: Date().addingTimeInterval(60), scopes: scopes, codeChallenge: nil, codeChallengeMethod: nil)
         fakeCodeManager.codes[newCodeString] = newCode
 
@@ -416,7 +417,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes ?? [], scopes)
+        XCTAssertEqual(accessToken.scopes, scopes)
     }
 
     func testTokenHasExpiryTimeSetOnIt() async throws {
@@ -491,7 +492,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(refreshToken.scopes ?? [], scopes)
+        XCTAssertEqual(refreshToken.scopes, scopes)
     }
 
     // MARK: - Private

--- a/Tests/VaporOAuthTests/GrantTests/AuthorizationCodeTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/AuthorizationCodeTokenTests.swift
@@ -39,7 +39,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
     let testClientSecret = "ABCDEFGHIJK"
     let testCodeID = "12345ABCD"
     let userID = "the-user-id"
-    let scopes = ["email", "create"]
+    let scopes = "email create"
     let testCodeChallenge = "testCodeChallenge"
     let testCodeChallengeMethod = "S256"
 
@@ -212,7 +212,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             redirectURI: "https://test.redirect.uri",
             userID: "testUserID",
             expiryDate: Date().addingTimeInterval(3600), // 1 hour in the future
-            scopes: ["testScope"],
+            scopes: "testScope",
             codeChallenge: nil, // No code challenge
             codeChallengeMethod: nil
         )
@@ -241,7 +241,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             redirectURI: "https://test.redirect.uri",
             userID: "testUserID",
             expiryDate: Date().addingTimeInterval(3600), // 1 hour in the future
-            scopes: ["testScope"],
+            scopes: "testScope",
             codeChallenge: codeChallenge, // Provided code challenge
             codeChallengeMethod: "S256"
         )
@@ -319,7 +319,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
     func testThatCorrectResponseReceivedWhenCorrectRequestSent() async throws {
         let accessToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         let refreshToken = "01234567890"
-        let scopes = ["email", "create"] // Assuming scopes is defined somewhere
+        let scopes = "email create"  // Defined as a space-delimited string
 
         fakeTokenManager.accessTokenToReturn = accessToken
         fakeTokenManager.refreshTokenToReturn = refreshToken
@@ -335,15 +335,15 @@ class AuthorizationCodeTokenTests: XCTestCase {
         XCTAssertEqual(responseJSON.expiresIn, 3600)
         XCTAssertEqual(responseJSON.accessToken, accessToken)
         XCTAssertEqual(responseJSON.refreshToken, refreshToken)
-        XCTAssertEqual(responseJSON.scope, scopes.joined(separator: " "))
+        XCTAssertEqual(responseJSON.scope, scopes)
 
         guard let token = fakeTokenManager.getAccessToken(accessToken) else {
             XCTFail("Access token not found")
             return
         }
 
-        let tokenScopes = token.scopes?.components(separatedBy: " ") ?? []
-        XCTAssertEqual(tokenScopes, scopes, "Token scopes do not match expected scopes")
+        // Directly compare the string values of scopes
+        XCTAssertEqual(token.scopes, scopes)
     }
 
     func testThatNoScopeReturnedIfNoneSetOnCode() async throws {
@@ -406,7 +406,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
         let accessTokenString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         fakeTokenManager.accessTokenToReturn = accessTokenString
         let newCodeString = "new-code-string"
-        let scopes = ["oneScope", "aDifferentScope"]
+        let scopes = "oneScope aDifferentScope"
         let newCode = OAuthCode(codeID: newCodeString, clientID: testClientID, redirectURI: testClientRedirectURI, userID: "user-id", expiryDate: Date().addingTimeInterval(60), scopes: scopes, codeChallenge: nil, codeChallengeMethod: nil)
         fakeCodeManager.codes[newCodeString] = newCode
 
@@ -417,10 +417,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             return
         }
 
-        // Assuming scopes in accessToken is a space-separated string
-        let accessTokenScopes = accessToken.scopes?.components(separatedBy: " ") ?? []
-
-        XCTAssertEqual(accessTokenScopes, scopes, "Access token scopes do not match expected scopes")
+        XCTAssertEqual(accessToken.scopes, scopes)
     }
     
     func testTokenHasExpiryTimeSetOnIt() async throws {
@@ -495,11 +492,7 @@ class AuthorizationCodeTokenTests: XCTestCase {
             return
         }
 
-        // Split the refreshToken.scopes string into an array, or default to an empty array if nil
-        let refreshTokenScopes = refreshToken.scopes?.components(separatedBy: " ") ?? []
-        
-        // Assuming `scopes` is an array of String for correct type comparison
-        XCTAssertEqual(refreshTokenScopes, scopes, "Refresh token scopes do not match expected scopes")
+        XCTAssertEqual(refreshToken.scopes, scopes)
     }
 
     // MARK: - Private

--- a/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
@@ -24,7 +24,7 @@ class ClientCredentialsTokenTests: XCTestCase {
             clientID: testClientID,
             redirectURIs: nil,
             clientSecret: testClientSecret,
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             confidential: true,
             allowedGrantType: .clientCredentials
         )
@@ -153,8 +153,8 @@ class ClientCredentialsTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes ?? [], ["email", "create"])
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(accessToken.scopes, "email create")
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
@@ -225,7 +225,7 @@ class ClientCredentialsTokenTests: XCTestCase {
 
     func testClientIDSetOnAccessTokenCorrectly() async throws {
         let newClientString = "a-new-client"
-        let newClient = OAuthClient(clientID: newClientString, redirectURIs: nil, clientSecret: testClientSecret, validScopes: [scope1, scope2], confidential: true, allowedGrantType: .clientCredentials)
+        let newClient = OAuthClient(clientID: newClientString, redirectURIs: nil, clientSecret: testClientSecret, validScopes: "\(scope1)\(scope2)", confidential: true, allowedGrantType: .clientCredentials)
         fakeClientGetter.validClients[newClientString] = newClient
 
         let response = try await getClientCredentialsResponse(clientID: newClientString)
@@ -284,7 +284,7 @@ class ClientCredentialsTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testNoUserIDSetOnRefreshToken() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
@@ -24,7 +24,7 @@ class ClientCredentialsTokenTests: XCTestCase {
             clientID: testClientID,
             redirectURIs: nil,
             clientSecret: testClientSecret,
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             confidential: true,
             allowedGrantType: .clientCredentials
         )
@@ -225,7 +225,7 @@ class ClientCredentialsTokenTests: XCTestCase {
 
     func testClientIDSetOnAccessTokenCorrectly() async throws {
         let newClientString = "a-new-client"
-        let newClient = OAuthClient(clientID: newClientString, redirectURIs: nil, clientSecret: testClientSecret, validScopes: [scope1, scope2], confidential: true, allowedGrantType: .clientCredentials)
+        let newClient = OAuthClient(clientID: newClientString, redirectURIs: nil, clientSecret: testClientSecret, validScopes: "\(scope1)\(scope2)", confidential: true, allowedGrantType: .clientCredentials)
         fakeClientGetter.validClients[newClientString] = newClient
 
         let response = try await getClientCredentialsResponse(clientID: newClientString)

--- a/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ClientCredentialsTokenTests.swift
@@ -153,8 +153,8 @@ class ClientCredentialsTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes ?? [], ["email", "create"])
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(accessToken.scopes, "email create")
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
@@ -284,7 +284,7 @@ class ClientCredentialsTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testNoUserIDSetOnRefreshToken() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/DeviceCodeGrantTests.swift
@@ -45,7 +45,7 @@ class DeviceCodeTokenTests: XCTestCase {
     let testClientID = "1234567890"
     let testDeviceCodeID = "DEVICE_CODE_ID"
     let userID = "the-user-id"
-    let scopes = ["email", "create"]
+    let scopes = "email create"
     
     // MARK: - Overrides
     
@@ -137,14 +137,16 @@ class DeviceCodeTokenTests: XCTestCase {
     
     func testThatCorrectResponseReceivedWhenCorrectRequestSent() async throws {
         let response = try await getDeviceCodeResponse()
-        
         XCTAssertEqual(response.status, .ok)
         let successResponse = try response.content.decode(SuccessResponse.self)
         XCTAssertEqual(successResponse.tokenType, "bearer")
         XCTAssertNotNil(successResponse.accessToken)
         XCTAssertNotNil(successResponse.expiresIn)
-        XCTAssertEqual(successResponse.scope, scopes.joined(separator: " "))
+        
+        // Directly compare the string value of scopes
+        XCTAssertEqual(successResponse.scope, scopes)
     }
+
     
     // MARK: - Private
     

--- a/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
@@ -30,7 +30,7 @@ class ImplicitGrantTests: XCTestCase {
         let oauthClient = OAuthClient(
             clientID: testClientID,
             redirectURIs: [testRedirectURIString],
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             allowedGrantType: .implicit
         )
 
@@ -115,7 +115,7 @@ class ImplicitGrantTests: XCTestCase {
     func testScopePassedThroughToAuthorizeHandlerIfProvided() async throws {
         _ = try await makeImplicitGrantRequest(scope: scope1)
 
-        XCTAssertEqual(capturingAuthHandler.scope ?? [], [scope1])
+        XCTAssertEqual(capturingAuthHandler.scope, scope1)
     }
 
     func testCorrectErrorReturnedIfRequestingUnknownScope() async throws {
@@ -330,7 +330,7 @@ class ImplicitGrantTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(token.scopes, "\(scope1) \(scope2)")
+        XCTAssertEqual(token.scopes, "\(scope1)\(scope2)")
         XCTAssertEqual(token.clientID, testClientID)
     }
 

--- a/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
@@ -30,7 +30,7 @@ class ImplicitGrantTests: XCTestCase {
         let oauthClient = OAuthClient(
             clientID: testClientID,
             redirectURIs: [testRedirectURIString],
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             allowedGrantType: .implicit
         )
 
@@ -115,7 +115,7 @@ class ImplicitGrantTests: XCTestCase {
     func testScopePassedThroughToAuthorizeHandlerIfProvided() async throws {
         _ = try await makeImplicitGrantRequest(scope: scope1)
 
-        XCTAssertEqual(capturingAuthHandler.scope ?? [], [scope1])
+        XCTAssertEqual(capturingAuthHandler.scope, scope1)
     }
 
     func testCorrectErrorReturnedIfRequestingUnknownScope() async throws {
@@ -330,7 +330,7 @@ class ImplicitGrantTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(token.scopes ?? [], [scope1, scope2])
+        XCTAssertEqual(token.scopes, "\(scope1)\(scope2)")
         XCTAssertEqual(token.clientID, testClientID)
     }
 

--- a/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/ImplicitGrantTests.swift
@@ -330,7 +330,7 @@ class ImplicitGrantTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(token.scopes ?? [], [scope1, scope2])
+        XCTAssertEqual(token.scopes, "\(scope1) \(scope2)")
         XCTAssertEqual(token.clientID, testClientID)
     }
 

--- a/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
@@ -45,7 +45,7 @@ class PasswordGrantTokenTests: XCTestCase {
             clientID: testClientID,
             redirectURIs: nil,
             clientSecret: testClientSecret,
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             firstParty: true,
             allowedGrantType: .password
         )
@@ -229,8 +229,8 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes, "email create")
-        XCTAssertEqual(refreshToken.scopes, "email create")
+        XCTAssertEqual(accessToken.scopes, scope)
+        XCTAssertEqual(refreshToken.scopes, scope)
     }
 
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
@@ -356,6 +356,7 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
+        XCTAssertEqual(refreshToken.scopes, "email create")
         XCTAssertEqual(refreshToken.scopes, "email create")
     }
 

--- a/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
@@ -229,8 +229,8 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes ?? [], ["email", "create"])
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(accessToken.scopes, "email create")
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
@@ -356,7 +356,7 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testUserIDSetOnRefreshToken() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
@@ -357,7 +357,6 @@ class PasswordGrantTokenTests: XCTestCase {
         }
 
         XCTAssertEqual(refreshToken.scopes, "email create")
-        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testUserIDSetOnRefreshToken() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/PasswordGrantTokenTests.swift
@@ -45,7 +45,7 @@ class PasswordGrantTokenTests: XCTestCase {
             clientID: testClientID,
             redirectURIs: nil,
             clientSecret: testClientSecret,
-            validScopes: [scope1, scope2],
+            validScopes: "\(scope1)\(scope2)",
             firstParty: true,
             allowedGrantType: .password
         )
@@ -229,8 +229,8 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(accessToken.scopes ?? [], ["email", "create"])
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(accessToken.scopes, scope)
+        XCTAssertEqual(refreshToken.scopes, scope)
     }
 
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
@@ -356,7 +356,7 @@ class PasswordGrantTokenTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(refreshToken.scopes ?? [], ["email", "create"])
+        XCTAssertEqual(refreshToken.scopes, "email create")
     }
 
     func testUserIDSetOnRefreshToken() async throws {

--- a/Tests/VaporOAuthTests/GrantTests/TokenRefreshTests.swift
+++ b/Tests/VaporOAuthTests/GrantTests/TokenRefreshTests.swift
@@ -1,10 +1,11 @@
 import XCTVapor
+import JWTKit
 @testable import VaporOAuth
 
 class TokenRefreshTests: XCTestCase {
-
+    
     // MARK: - Properties
-
+    
     var app: Application!
     var fakeClientGetter: FakeClientGetter!
     var fakeTokenManager: FakeTokenManager!
@@ -16,19 +17,19 @@ class TokenRefreshTests: XCTestCase {
     let scope3 = "edit"
     let scope4 = "profile"
     var validRefreshToken: RefreshToken!
-
+    
     // MARK: - Overrides
-
+    
     override func setUp() {
         fakeClientGetter = FakeClientGetter()
         fakeTokenManager = FakeTokenManager()
-
+        
         app = try! TestDataBuilder.getOAuth2Application(
             tokenManager: fakeTokenManager,
             clientRetriever: fakeClientGetter,
             validScopes: [scope1, scope2, scope3, scope4]
         )
-
+        
         let testClient = OAuthClient(
             clientID: testClientID,
             redirectURIs: nil,
@@ -42,158 +43,158 @@ class TokenRefreshTests: XCTestCase {
             jti: refreshTokenString,
             clientID: testClientID,
             userID: nil,
-            scopes: [scope1, scope2], exp: Date().addingTimeInterval(60)
+            scopes: "\(scope1) \(scope2)", exp: Date().addingTimeInterval(60)
         )
         fakeTokenManager.refreshTokens[refreshTokenString] = validRefreshToken
     }
-
+    
     override func tearDown() async throws {
         app.shutdown()
         try await super.tearDown()
     }
-
+    
     // MARK: - Tests
     func testCorrectErrorWhenGrantTypeNotSupplied() async throws {
         let response = try await getTokenResponse(grantType: nil)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_request")
         XCTAssertEqual(responseJSON.errorDescription, "Request was missing the 'grant_type' parameter")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorAndHeadersReceivedWhenIncorrectGrantTypeSet() async throws {
         let grantType = "some_unknown_type"
         let response = try await getTokenResponse(grantType: grantType)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "unsupported_grant_type")
         XCTAssertEqual(responseJSON.errorDescription, "This server does not support the '\(grantType)' grant type")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorWhenClientIDNotSupplied() async throws {
         let response = try await getTokenResponse(clientID: nil)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_request")
         XCTAssertEqual(responseJSON.errorDescription, "Request was missing the 'client_id' parameter")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorWhenClientIDNotValid() async throws {
         let response = try await getTokenResponse(clientID: "UNKNOWN_CLIENT")
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .unauthorized)
         XCTAssertEqual(responseJSON.error, "invalid_client")
         XCTAssertEqual(responseJSON.errorDescription, "Request had invalid client credentials")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorWhenClientDoesNotAuthenticate() async throws {
         let response = try await getTokenResponse(clientSecret: "incorrectPassword")
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .unauthorized)
         XCTAssertEqual(responseJSON.error, "invalid_client")
         XCTAssertEqual(responseJSON.errorDescription, "Request had invalid client credentials")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorIfClientSecretNotSent() async throws {
         let response = try await getTokenResponse(clientSecret: nil)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_request")
         XCTAssertEqual(responseJSON.errorDescription, "Request was missing the 'client_secret' parameter")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrrIfRefreshTokenNotSent() async throws {
         let response = try await getTokenResponse(refreshToken: nil)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_request")
         XCTAssertEqual(responseJSON.errorDescription, "Request was missing the 'refresh_token' parameter")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testThatNonConfidentialClientsGetErrorWhenRequestingToken() async throws {
         let nonConfidentialClientID = "NONCONF"
         let nonConfidentialClientSecret = "SECRET"
         let nonConfidentialClient = OAuthClient(clientID: nonConfidentialClientID, redirectURIs: nil, clientSecret: nonConfidentialClientSecret, confidential: false, allowedGrantType: .authorization)
         fakeClientGetter.validClients[nonConfidentialClientID] = nonConfidentialClient
-
+        
         let response = try await getTokenResponse(clientID: nonConfidentialClientID, clientSecret: nonConfidentialClientSecret)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "unauthorized_client")
         XCTAssertEqual(responseJSON.errorDescription, "You are not authorized to use the Client Credentials grant type")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testThatAttemptingRefreshWithNonExistentTokenReturnsError() async throws {
         let expiredRefreshToken = "NONEXISTENTTOKEN"
-
+        
         let response = try await getTokenResponse(refreshToken: expiredRefreshToken)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_grant")
         XCTAssertEqual(responseJSON.errorDescription, "The refresh token is invalid")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testThatAttemptingRefreshWithRefreshTokenFromDifferentClientReturnsError() async throws {
         let otherClientID = "ABCDEFGHIJKLMON"
         let otherClientSecret = "1234"
         let otherClient = OAuthClient(clientID: otherClientID, redirectURIs: nil, clientSecret: otherClientSecret, confidential: true, allowedGrantType: .authorization)
         fakeClientGetter.validClients[otherClientID] = otherClient
-
+        
         let response = try await getTokenResponse(clientID: otherClientID, clientSecret: otherClientSecret)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_grant")
         XCTAssertEqual(responseJSON.errorDescription, "The refresh token is invalid")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     
     func testThatProvidingValidRefreshTokenProvidesAccessTokenInResponse() async throws {
         let accessToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         fakeTokenManager.accessTokenToReturn = accessToken
         let response = try await getTokenResponse()
-
+        
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .ok)
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
@@ -202,200 +203,288 @@ class TokenRefreshTests: XCTestCase {
         XCTAssertEqual(responseJSON.accessToken, accessToken)
         XCTAssertNil(responseJSON.refreshToken)
     }
-
+    
     func testCorrectErrorWhenReqeustingScopeApplicationDoesNotHaveAccessTo() async throws {
         let scope = "email edit"
-
+        
         let response = try await getTokenResponse(scope: scope)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_scope")
         XCTAssertEqual(responseJSON.errorDescription, "Request contained an invalid scope")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testCorrectErrorWhenRequestingUnknownScope() async throws {
         let scope = "email unknown"
-
+        
         let response = try await getTokenResponse(scope: scope)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_scope")
         XCTAssertEqual(responseJSON.errorDescription, "Request contained an unknown scope")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testErrorIfRequestingScopeGreaterThanOriginallyRequestedEvenIfApplicatioHasAccess() async throws {
         let response = try await getTokenResponse(scope: "\(scope1) \(scope4)")
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_scope")
         XCTAssertEqual(responseJSON.errorDescription, "Request contained elevated scopes")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testLoweringScopeOnRefreshSetsScopeCorrectlyOnAccessAndRefreshTokens() async throws {
         let response = try await getTokenResponse(scope: scope1)
-
+        
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
+        
         guard let accessTokenString = responseJSON.accessToken else {
-            XCTFail()
+            XCTFail("No access token found in response")
             return
         }
+        
+        var signers = JWTSigners()
+        signers.use(.hs256(key: "dummySecret")) // Use the actual key and algorithm
+        
+        do {
+            // Decode the access token to verify its scopes
+            let jwt = try signers.verify(accessTokenString, as: MyAccessToken.self)
+            guard let accessTokenScopes = jwt.scopes else {
+                XCTFail("Access token does not contain scopes")
+                return
+            }
+            
+            // Assuming accessToken.scopes is a space-separated string
+            XCTAssertEqual(accessTokenScopes, scope1, "Access token scopes do not match the expected scope")
 
-        guard let accessToken = fakeTokenManager.getAccessToken(accessTokenString) else {
-            XCTFail()
+        } catch {
+            XCTFail("Failed to decode JWT: \(error)")
             return
         }
-
-        XCTAssertEqual(accessToken.scopes ?? [], [scope1])
-
+        
         XCTAssertEqual(response.status, .ok)
         XCTAssertEqual(responseJSON.scope, scope1)
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
-
+        
+        // Optionally, verify the refresh token's scopes as well, if stored separately and not as a JWT
         guard let refreshToken = fakeTokenManager.getRefreshToken(refreshTokenString) else {
-            XCTFail()
+            XCTFail("Failed to retrieve refresh token")
             return
         }
-
-        XCTAssertEqual(refreshToken.scopes ?? [], [scope1])
+        
+        // Assuming refreshToken.scopes is also a space-separated string or directly comparable to scope1
+        XCTAssertEqual(refreshToken.scopes, scope1, "Refresh token scopes do not match the expected scope")
     }
-
+    
     func testNotRequestingScopeOnRefreshDoesNotAlterOriginalScope() async throws {
-        let originalScopes = validRefreshToken.scopes
-
-        let response = try await getTokenResponse()
-
+        let originalScopes = validRefreshToken.scopes // Assuming this is a String representing scopes
+        
+        let response = try await getTokenResponse() // Simulate token refresh/response
+        
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
-        guard let accessTokenString = responseJSON.accessToken,
-              let accessToken = fakeTokenManager.getAccessToken(accessTokenString) else {
-            XCTFail()
+        
+        guard let accessTokenString = responseJSON.accessToken else {
+            XCTFail("No access token found in response")
             return
         }
+        
+        var signers = JWTSigners()
+        signers.use(.hs256(key: "dummySecret")) // Use the appropriate key and algorithm
+        
+        // Decode the JWT to verify its scopes
+        do {
+            let jwt = try signers.verify(accessTokenString, as: MyAccessToken.self)
+            guard let accessTokenScopes = jwt.scopes else {
+                XCTFail("Access token does not contain scopes")
+                return
+            }
 
-        guard let refreshToken = fakeTokenManager.getRefreshToken(refreshTokenString) else {
-            XCTFail()
-            return
+            // Since we are assuming the scopes are a space-separated string, compare them directly
+            XCTAssertEqual(accessTokenScopes, originalScopes, "Access token scopes have been altered")
+
+            // Optionally, if you need to compare the refresh token scopes as well:
+            guard let refreshToken = fakeTokenManager.getRefreshToken(refreshTokenString) else {
+                XCTFail("Failed to retrieve refresh token")
+                return
+            }
+            
+            // Assuming the refreshToken.scopes is also a String
+            XCTAssertEqual(refreshToken.scopes, originalScopes, "Refresh token scopes have been altered")
+            
+        } catch {
+            XCTFail("Failed to decode JWT: \(error)")
         }
-
-        XCTAssertEqual(accessToken.scopes!, originalScopes ?? [])
-        XCTAssertEqual(refreshToken.scopes!, originalScopes!)
-
     }
-
+    
     func testRequestingTheSameScopeWhenRefreshingWorksCorrectlyAndReturnsResult() async throws {
+        // Ensure scopesToRequest is correctly initialized from validRefreshToken
         let scopesToRequest = validRefreshToken.scopes
-        let response = try await getTokenResponse(scope: scopesToRequest?.joined(separator: " "))
-
+        
+        // Request token
+        let response = try await getTokenResponse(scope: scopesToRequest)
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
-        guard let accessTokenString = responseJSON.accessToken,
-              let accessToken = fakeTokenManager.getAccessToken(accessTokenString) else {
-            XCTFail()
+        
+        // Set up JWTSigners
+        var signers = JWTSigners()
+        signers.use(.hs256(key: "dummySecret"))
+        
+        // Extract accessTokenString from response
+        guard let accessTokenString = responseJSON.accessToken else {
+            XCTFail("No access token found in response")
             return
         }
-
+        
+        var scopes: String? = nil // Initialize `scopes` here to ensure it's always initialized before use
+        
+        do {
+            // Decode JWT
+            let jwt = try signers.verify(accessTokenString, as: MyAccessToken.self)
+            scopes = jwt.scopes // Assign decoded scopes to the `scopes` variable
+        } catch {
+            XCTFail("Failed to decode JWT: \(error)")
+            return // Ensure exit from function upon failure
+        }
+        
+        // Validate that the refreshed token has the requested scopes
         guard let refreshToken = fakeTokenManager.getRefreshToken(refreshTokenString) else {
-            XCTFail()
+            XCTFail("Failed to retrieve refresh token")
             return
         }
-
-        XCTAssertEqual(accessToken.scopes!, scopesToRequest ?? [])
-        XCTAssertEqual(refreshToken.scopes!, scopesToRequest!)
+        
+        // Safely unwrap and compare scopes
+        if let refreshTokenScopes = refreshToken.scopes, let requestedScopes = scopesToRequest {
+            XCTAssertEqual(refreshTokenScopes, requestedScopes, "Refresh token scopes do not match requested scopes")
+        } else {
+            XCTFail("Scopes are nil or not available")
+        }
+        
+        // Optionally, compare scopes from the JWT with the requested scopes directly
+        XCTAssertEqual(scopes, scopesToRequest, "Access token scopes do not match requested scopes")
     }
-
+    
     func testErrorWhenRequestingScopeWithNoScopesOriginallyRequestedOnRefreshToken() async throws {
         let newRefreshToken = "NEW_REFRESH_TOKEN"
         let refreshTokenWithoutScope = FakeRefreshToken(jti: newRefreshToken, clientID: testClientID, userID: nil, scopes: nil, exp: Date().addingTimeInterval(60))
         fakeTokenManager.refreshTokens[newRefreshToken] = refreshTokenWithoutScope
-
+        
         let response = try await getTokenResponse(refreshToken: newRefreshToken, scope: scope1)
-
+        
         let responseJSON = try JSONDecoder().decode(ErrorResponse.self, from: response.body)
-
+        
         XCTAssertEqual(response.status, .badRequest)
         XCTAssertEqual(responseJSON.error, "invalid_scope")
         XCTAssertEqual(responseJSON.errorDescription, "Request contained elevated scopes")
         XCTAssertEqual(response.headers.cacheControl?.noStore, true)
         XCTAssertEqual(response.headers[HTTPHeaders.Name.pragma], ["no-cache"])
     }
-
+    
     func testUserIDIsSetOnAccessTokenIfRefreshTokenHasOne() async throws {
         let userID = "abcdefg-123456"
         let accessToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         let userIDRefreshTokenString = "ASHFUIEWHFIHEWIUF"
-        let userIDRefreshToken = FakeRefreshToken(jti: userIDRefreshTokenString, clientID: testClientID, userID: userID, scopes: [scope1, scope2], exp: Date().addingTimeInterval(60))
+        let userIDRefreshToken = FakeRefreshToken(jti: userIDRefreshTokenString, clientID: testClientID, userID: userID, scopes: "\(scope1) \(scope2)", exp: Date().addingTimeInterval(60))
         fakeTokenManager.refreshTokens[userIDRefreshTokenString] = userIDRefreshToken
         fakeTokenManager.accessTokenToReturn = accessToken
         _ = try await getTokenResponse(refreshToken: userIDRefreshTokenString)
-
+        
         guard let token = fakeTokenManager.getAccessToken(accessToken) else {
             XCTFail()
             return
         }
-
+        
         XCTAssertEqual(token.userID, userID)
     }
-
+    
     func testClientIDSetOnAccessTokenFromRefreshToken() async throws {
         let refreshTokenString = "some-new-refreshToken"
         let clientID = "the-client-id-to-set"
         let refreshToken = FakeRefreshToken(jti: refreshTokenString, clientID: clientID, userID: "some-user", exp: Date().addingTimeInterval(60))
+        
+        // Set up the mock refresh token in your fake token manager
         fakeTokenManager.refreshTokens[refreshTokenString] = refreshToken
+        
+        // Configure a mock OAuth client that's considered valid
         fakeClientGetter.validClients[clientID] = OAuthClient(clientID: clientID, redirectURIs: nil, clientSecret: testClientSecret, confidential: true, allowedGrantType: .authorization)
-
+        
+        // Attempt to get a new token response using the refresh token
         let response = try await getTokenResponse(clientID: clientID, refreshToken: refreshTokenString)
+        
+        // Decode the response to obtain the access token string
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
+        
         guard let accessTokenString = responseJSON.accessToken else {
-            XCTFail()
+            XCTFail("No access token found in response")
             return
         }
-
-        guard let accessToken = fakeTokenManager.getAccessToken(accessTokenString) else {
-            XCTFail()
-            return
+        
+        var signers = JWTSigners()
+        signers.use(.hs256(key: "dummySecret"))
+        
+        do {
+            let jwt = try signers.verify(accessTokenString, as: MyAccessToken.self)
+            let accessTokenJti = jwt.jti
+            
+            // Retrieve the access token details using the token string
+            guard let accessToken = fakeTokenManager.getAccessToken(accessTokenJti) else {
+                XCTFail("Failed to retrieve access token details")
+                return
+            }
+            
+            // Assert that the clientID of the retrieved access token matches the expected clientID
+            XCTAssertEqual(accessToken.clientID, clientID, "Access token clientID does not match the expected clientID")
+            
+        } catch {
+            XCTFail("Failed to decode JWT: \(error)")
         }
-
-        XCTAssertEqual(accessToken.clientID, clientID)
-
+        
     }
-
+    
     func testExpiryTimeSetOnNewAccessToken() async throws {
+        
         let currentTime = Date()
         fakeTokenManager.currentTime = currentTime
-
+        
         let response = try await getTokenResponse()
         let responseJSON = try JSONDecoder().decode(SuccessResponse.self, from: response.body)
-
+        
         guard let accessTokenString = responseJSON.accessToken else {
-            XCTFail()
+            XCTFail("Access token not found in response")
             return
         }
-
-        guard let accessToken = fakeTokenManager.getAccessToken(accessTokenString) else {
-            XCTFail()
-            return
+        
+        var signers = JWTSigners()
+        signers.use(.hs256(key: "dummySecret"))
+        
+        do {
+            let jwt = try signers.verify(accessTokenString, as: MyAccessToken.self)
+            
+            // Verify the expiry time directly with the Date object
+            let expectedExpiryTime = currentTime.addingTimeInterval(3600)
+            let accessTokenExpiryTime = jwt.expiryTime
+            
+            // Calculate the time difference and assert it's within 5 seconds tolerance
+            let timeDifference = accessTokenExpiryTime.timeIntervalSince(expectedExpiryTime)
+            XCTAssertTrue(abs(timeDifference) <= 5, "Access token expiry time is not within the expected range")
+        } catch {
+            XCTFail("Failed to decode JWT: \(error)")
         }
-
-        XCTAssertEqual(accessToken.expiryTime, currentTime.addingTimeInterval(3600))
     }
-
+    
+    
     // MARK: - Private
-
+    
     func getTokenResponse(
         grantType: String? = "refresh_token",
         clientID: String? = "ABCDEF",
@@ -412,5 +501,13 @@ class TokenRefreshTests: XCTestCase {
             refreshToken: refreshToken
         )
     }
-
+    
+    struct MyAccessToken: AccessToken {
+        var jti: String
+        var clientID: String
+        var userID: String?
+        var scopes: String?
+        var expiryTime: Date
+    }
+    
 }

--- a/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
+++ b/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
@@ -250,7 +250,7 @@ class AuthCodeResourceServerTests: XCTestCase {
             jti: tokenID,
             clientID: newClientID,
             userID: newUser.id,
-            scopes: ["invalid"],
+            scopes: "invalid",
             expiryTime: Date().addingTimeInterval(3600)
         )
         fakeTokenManager.accessTokens[tokenID] = token
@@ -264,7 +264,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testAccessingProtectedRouteWithOneInvalidScopeOneValidReturns401() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: ["invalid", scope], expiryTime: Date().addingTimeInterval(3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "invalid\(scope)", expiryTime: Date().addingTimeInterval(3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in
@@ -276,7 +276,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testAccessingProtectedRouteWithLowercaseHeaderWorks() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: [scope, scope2], expiryTime: Date().addingTimeInterval(3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "\(scope)\(scope2)", expiryTime: Date().addingTimeInterval(3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in
@@ -288,7 +288,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testThatAccessingProtectedRouteWithExpiredTokenReturns401() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: [scope, scope2], expiryTime: Date().addingTimeInterval(-3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "\(scope)\(scope2)", expiryTime: Date().addingTimeInterval(-3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in

--- a/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
+++ b/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
@@ -26,7 +26,7 @@ class AuthCodeResourceServerTests: XCTestCase {
             clientID: newClientID,
             redirectURIs: [redirectURI],
             clientSecret: clientSecret,
-            validScopes: [scope, scope2],
+            validScopes: "scope scope2",
             confidential: true,
             firstParty: true,
             allowedGrantType: .authorization
@@ -385,7 +385,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
 struct TestResourceController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        let oauthMiddleware = OAuth2ScopeMiddleware(requiredScopes: ["user", "email"])
+        let oauthMiddleware = OAuth2ScopeMiddleware(requiredScopes: "user email")
         let protected = routes.grouped(oauthMiddleware)
 
         protected.get("protected", use: protectedHandler)
@@ -409,7 +409,7 @@ struct TestResourceController: RouteCollection {
 struct RemoteResourceController: RouteCollection {
     let client: Client
     func boot(routes: RoutesBuilder) throws {
-        let oauthMiddleware = OAuth2TokenIntrospectionMiddleware(requiredScopes: ["user", "email"])
+        let oauthMiddleware = OAuth2TokenIntrospectionMiddleware(requiredScopes: "user email")
         let protected = routes.grouped(oauthMiddleware)
 
         protected.get("protected", use: protectedHandler)

--- a/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
+++ b/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
@@ -26,7 +26,7 @@ class AuthCodeResourceServerTests: XCTestCase {
             clientID: newClientID,
             redirectURIs: [redirectURI],
             clientSecret: clientSecret,
-            validScopes: [scope, scope2],
+            validScopes: "scope scope2",
             confidential: true,
             firstParty: true,
             allowedGrantType: .authorization
@@ -250,7 +250,7 @@ class AuthCodeResourceServerTests: XCTestCase {
             jti: tokenID,
             clientID: newClientID,
             userID: newUser.id,
-            scopes: ["invalid"],
+            scopes: "invalid",
             expiryTime: Date().addingTimeInterval(3600)
         )
         fakeTokenManager.accessTokens[tokenID] = token
@@ -264,7 +264,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testAccessingProtectedRouteWithOneInvalidScopeOneValidReturns401() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: ["invalid", scope], expiryTime: Date().addingTimeInterval(3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "invalid\(scope)", expiryTime: Date().addingTimeInterval(3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in
@@ -276,7 +276,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testAccessingProtectedRouteWithLowercaseHeaderWorks() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: [scope, scope2], expiryTime: Date().addingTimeInterval(3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "\(scope)\(scope2)", expiryTime: Date().addingTimeInterval(3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in
@@ -288,7 +288,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
     func testThatAccessingProtectedRouteWithExpiredTokenReturns401() async throws {
         let tokenID = "new-token-ID-invalid-scope"
-        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: [scope, scope2], expiryTime: Date().addingTimeInterval(-3600))
+        let token = FakeAccessToken(jti: tokenID, clientID: newClientID, userID: newUser.id, scopes: "\(scope)\(scope2)", expiryTime: Date().addingTimeInterval(-3600))
         fakeTokenManager.accessTokens[tokenID] = token
 
         try app.test(.GET, "/protected/", beforeRequest: { req in
@@ -385,7 +385,7 @@ class AuthCodeResourceServerTests: XCTestCase {
 
 struct TestResourceController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        let oauthMiddleware = OAuth2ScopeMiddleware(requiredScopes: ["user", "email"])
+        let oauthMiddleware = OAuth2ScopeMiddleware(requiredScopes: "user email")
         let protected = routes.grouped(oauthMiddleware)
 
         protected.get("protected", use: protectedHandler)
@@ -409,7 +409,7 @@ struct TestResourceController: RouteCollection {
 struct RemoteResourceController: RouteCollection {
     let client: Client
     func boot(routes: RoutesBuilder) throws {
-        let oauthMiddleware = OAuth2TokenIntrospectionMiddleware(requiredScopes: ["user", "email"])
+        let oauthMiddleware = OAuth2TokenIntrospectionMiddleware(requiredScopes: "user email")
         let protected = routes.grouped(oauthMiddleware)
 
         protected.get("protected", use: protectedHandler)

--- a/Tests/VaporOAuthTests/TokenIntrospectionTests/TokenIntrospectionTests.swift
+++ b/Tests/VaporOAuthTests/TokenIntrospectionTests/TokenIntrospectionTests.swift
@@ -114,7 +114,7 @@ class TokenIntrospectionTests: XCTestCase {
 
     func testThatScopeReturnedInReponseIfTokenHasScope() async throws {
         let tokenString = "VALID_TOKEN"
-        let validToken = FakeAccessToken(jti: tokenString, clientID: clientID, userID: nil, scopes: ["email", "profile"], expiryTime: Date().addingTimeInterval(60))
+        let validToken = FakeAccessToken(jti: tokenString, clientID: clientID, userID: nil, scopes: "email profile", expiryTime: Date().addingTimeInterval(60))
         fakeTokenManager.accessTokens[tokenString] = validToken
 
         let response = try await getInfoResponse(token: tokenString)


### PR DESCRIPTION
This pull request introduces a significant update to OAuth implementation, specifically focusing on the handling of the `scopes` property. In alignment with OAuth RFC standards, we have transitioned the `scopes` property from being an array to a single string. This change ensures compliance with OAuth specifications and enhances the interoperability of OAuth handling.

#### Changes
- The `scopes` property across the application, previously an array of strings, has been updated to a single space-delimited string.
- Updated all relevant instances where `scopes` are processed, parsed, or stored to reflect this change.
- Modified existing tests to adapt to the new string-based `scopes` property. Tests now validate against a single string rather than an array of strings, ensuring consistency with OAuth RFC recommendations.

#### Impact
- This change brings OAuth implementation in line with industry standards as specified in the OAuth RFC.
- It simplifies the handling of scopes by treating them as a single string, streamlining our codebase and reducing complexity.
- Existing integrations or custom implementations that rely on the previous array-based approach will need to be updated to accommodate this change.

#### Background
According to the OAuth RFC, the `scope` parameter should be represented as a list of space-delimited, case-sensitive strings. This format allows for a more flexible and standardized way of representing scopes, facilitating better interoperability across different systems and OAuth providers.

- Resolves #11 